### PR TITLE
Fix format() edge case

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,9 @@
 const format = (structure, data) =>
   Object.keys(structure).reduce(
     (acc, key) => Object.assign({}, acc,
-      { [key]: data[key] ? structure[key](data[key])
-                         : null }),
+      { [key]: (data[key] !== undefined && data[key] !== null)
+                  ? structure[key](data[key])
+                  : null }),
     {})
 
 // Given a node, format its contents according to a given structure,


### PR DESCRIPTION
It would classify a key as null if its value is 0

Example Node:
`{ id: 0, name: "John" }`

In this case, it doesn't matter what validator/converter we assign to the field 'id', as it would evaluate as false by `data[key] ?`